### PR TITLE
avoid using conflicting ports

### DIFF
--- a/run-containers.sh
+++ b/run-containers.sh
@@ -4,7 +4,7 @@
 podman run -d --name redis-stack -p 6379:6379 -p 8001:8001 docker.io/redis/redis-stack:latest
 
 # Run of HTTPD
-podman run -dt -p 8080:80/tcp docker.io/library/httpd
+podman run -dt -p 8082:80/tcp docker.io/library/httpd
 
 # Run of with Volume
-podman run --name nginx-earthly -d -p 8000:80 -v demo-earthly:/usr/share/nginx/html docker.io/nginx
+podman run --name nginx-earthly -d -p 8003:80 -v demo-earthly:/usr/share/nginx/html docker.io/nginx


### PR DESCRIPTION
In order to avoid conflicting ports with other parts of the script, use different ones