### PR TITLE
chore: publish frontend image when doing changes in the main branch

### DIFF
--- a/.github/workflows/build-publish-podify-demo.yaml
+++ b/.github/workflows/build-publish-podify-demo.yaml
@@ -1,0 +1,72 @@
+---
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build and publish the images of podify demo
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "primary-podify-demo/frontend/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build Frontend Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: podify-demo-frontend
+          tags: v1 ${{ github.sha }}
+          containerfiles: |
+            ./primary-podify-demo/front/Dockerfile
+          context: ./primary-podify-demo/front
+          archs: amd64, arm64
+
+      - name: Echo Outputs
+        run: |
+          echo "Image: ${{ steps.build-image.outputs.image }}"
+          echo "Tags: ${{ steps.build-image.outputs.tags }}"
+          echo "Tagged Image: ${{ steps.build-image.outputs.image-with-tag }}"
+
+      - name: Log in to Red Hat Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/podman-desktop-demo


### PR DESCRIPTION
It'll publish to https://quay.io/repository/podman-desktop-demo/podify-demo-frontend

part of https://github.com/redhat-developer/podman-desktop-demo/issues/18