### PR TITLE
feat: add Dockerfile for the backend

### DIFF
--- a/.github/workflows/build-publish-podify-demo-backend.yaml
+++ b/.github/workflows/build-publish-podify-demo-backend.yaml
@@ -16,14 +16,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Build and publish the images of podify demo
+name: Build and publish the backend image of podify demo
 
 on:
   push:
     branches:
       - main
     paths:
-      - "primary-podify-demo/frontend/**"
+      - "primary-podify-demo/backend/**"
   workflow_dispatch:
 
 jobs:
@@ -39,15 +39,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
 
-      - name: Build Frontend Image
+      - name: Build Backend Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: podify-demo-frontend
+          image: podify-demo-backend
           tags: v1 ${{ github.sha }}
           containerfiles: |
-            ./primary-podify-demo/front/Dockerfile
-          context: ./primary-podify-demo/front
+            ./primary-podify-demo/backend/Dockerfile
+          context: ./primary-podify-demo/backend
           archs: amd64, arm64
 
       - name: Echo Outputs

--- a/.github/workflows/build-publish-podify-demo-frontend.yaml
+++ b/.github/workflows/build-publish-podify-demo-frontend.yaml
@@ -1,0 +1,72 @@
+---
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build and publish the frontend image of podify demo
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "primary-podify-demo/frontend/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build Frontend Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: podify-demo-frontend
+          tags: v1 ${{ github.sha }}
+          containerfiles: |
+            ./primary-podify-demo/front/Dockerfile
+          context: ./primary-podify-demo/front
+          archs: amd64, arm64
+
+      - name: Echo Outputs
+        run: |
+          echo "Image: ${{ steps.build-image.outputs.image }}"
+          echo "Tags: ${{ steps.build-image.outputs.tags }}"
+          echo "Tagged Image: ${{ steps.build-image.outputs.image-with-tag }}"
+
+      - name: Log in to Red Hat Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/podman-desktop-demo

--- a/primary-podify-demo/backend/Dockerfile
+++ b/primary-podify-demo/backend/Dockerfile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# UBI Builder
+FROM registry.access.redhat.com/ubi9/ubi:9.2-755 AS ubi-builder
+
+# REDIS version to use and the origin
+ENV REDIS_VERSION 7.2.1
+ENV REDIS_DOWNLOAD_URL http://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz
+
+# create rootfs directory where to copy the final filesystem
+RUN mkdir -p /mnt/rootfs
+
+# install redis
+RUN curl -sSL ${REDIS_DOWNLOAD_URL} -o /redis.tar.gz \
+    && mkdir -p /usr/src/redis \
+    && tar -xzf redis.tar.gz -C /usr/src/redis --strip-components=1 \
+    && rm /redis.tar.gz
+
+# install make tools
+RUN yum install -y make gcc 
+
+# install runtime tools
+RUN yum install --installroot /mnt/rootfs coreutils-single curl shadow-utils \
+    --releasever 8 --nodocs -y && \
+    yum --installroot /mnt/rootfs clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
+
+# use the final root filesystem as default directory
+WORKDIR /mnt/rootfs
+
+# apply permissions to later change these files (entrypoint update_extension_vsx_references)
+RUN make -C /usr/src/redis -j "$(nproc)" all && make -C /usr/src/redis install
+
+# Display the CLI's version
+RUN redis-cli --version && redis-server --version
+
+# Copy redis binaries to the rootfs
+RUN cp /usr/local/bin/redis-server /mnt/rootfs/usr/local/bin/redis-server
+
+# Configure quickly redis
+RUN echo -e "port 6379\nprotected-mode no\n" > /mnt/rootfs/etc/redis.conf
+
+# Use scratch image and then copy ubi fs
+FROM scratch
+COPY --from=ubi-builder /mnt/rootfs/ /
+# Create redis user
+RUN groupadd -g 1000 redis && useradd -u 1000 -g redis -G root redis
+USER redis
+# start the database as entrypoint
+ENTRYPOINT ["/usr/local/bin/redis-server", "/etc/redis.conf"]


### PR DESCRIPTION
- replace centos7 image by a ubi image (and yes we can't use rhel8/ubi8 images as they're internal)
  * Use the ubi builder pattern so image is small
  * use a recent version of Redis (current image was redis 5, now it's v7.2.1)
- centos image is only amd64 while for example on my mac I'm using ARM64
- automatically build the image when we do changes to the folder

for now it doesn't change anything in the demo as the image is not used

Image size goes from 281MB to 84MB