### PR TITLE
Change USER from alphabatic to numeric

### DIFF
--- a/primary-podify-demo/backend/Dockerfile
+++ b/primary-podify-demo/backend/Dockerfile
@@ -60,6 +60,6 @@ FROM scratch
 COPY --from=ubi-builder /mnt/rootfs/ /
 # Create redis user
 RUN groupadd -g 1000 redis && useradd -u 1000 -g redis -G root redis
-USER redis
+USER 1000
 # start the database as entrypoint
 ENTRYPOINT ["/usr/local/bin/redis-server", "/etc/redis.conf"]

--- a/primary-podify-demo/front/Dockerfile
+++ b/primary-podify-demo/front/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=python-builder / /
 # expose frontend port
 EXPOSE 5000
 
-USER frontend
+USER 1000
 
 WORKDIR /app
 


### PR DESCRIPTION
Looks like when you run these image on microshift then pod is not starting and failing with following error.
```
 message: 'container has runAsNonRoot and image has non-numeric user (redis),
          cannot verify user is non-root (pod: "microshift-python-pod_default(dd67b958-f807-47cb-ab7a-9f4f022f2658)",
          container: redis-podified)'
        reason: CreateContainerConfigError
```

This PR should fix that and container can run with podman and openshift environment.