### PR TITLE
Fixed bug in non-RHEL machines, added support for PowerShell

### DIFF
--- a/primary-podify-demo/front/Dockerfile
+++ b/primary-podify-demo/front/Dockerfile
@@ -31,8 +31,8 @@ RUN yum install --installroot /mnt/rootfs coreutils-single curl shadow-utils \
 # use the final root filesystem as default directory
 WORKDIR /mnt/rootfs
 
-COPY ./entrypoint.sh /mnt/rootfs
-RUN chmod +x /mnt/rootfs/entrypoint.sh
+COPY ./start.sh /mnt/rootfs
+RUN chmod +x /mnt/rootfs/start.sh
 
 FROM scratch as python-builder
 COPY --from=ubi-builder /mnt/rootfs/ /
@@ -65,4 +65,4 @@ WORKDIR /app
 ENV FLASK_APP=app.py FLASK_RUN_HOST=0.0.0.0
 
 # start flask
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/start.sh"]

--- a/primary-podify-demo/front/start.sh
+++ b/primary-podify-demo/front/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# use redis hostname if available, otherwise use localhost
+if getent hosts redis 1>/dev/null;
+then
+      export APP_SERVER="redis"
+else
+      export APP_SERVER="localhost"
+fi
+echo Using redis host ${APP_SERVER}
+sed -i "s/{APP_SERVER}/${APP_SERVER}/" /app/app.py
+flask run

--- a/primary-podify-demo/preload.ps1
+++ b/primary-podify-demo/preload.ps1
@@ -1,0 +1,15 @@
+# PowerShell
+
+if (-Not {podman network exists podify}) {
+    podman network create podify
+}
+
+if ({podman container exists redis}) {
+    podman rm -f redis
+}
+podman run -d -p 6379:6379 --net podify --name redis quay.io/podman-desktop-demo/podify-demo-backend:v1
+
+if ({podman container exists python-frontend}) {
+    podman rm -f python-frontend
+}
+podman run -d -p 8088:5000 --net podify --name python-frontend quay.io/podman-desktop-demo/podify-demo-frontend:v1


### PR DESCRIPTION
In the Dockerfile, it calls "entrypoint.sh". This does not work in non-RHEL machines. Simply renaming this to startup.sh fixes this.

I also added PowerShell support in the podify directory, i.e. preload.ps1. Windows users are now included.