### PR TITLE
feat: podman icon

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,21 @@
         "title": "Cleanup images",
         "category": "Podman Desktop Demo"
       }
-    ]
+    ],
+    "views": {
+      "icons/containersList": [
+        {
+          "when": "io.podman.demo in containerLabelKeys",
+          "icon": "${podman-icon}"
+        }
+      ],
+      "icons/image": [
+        {
+          "when": "io.podman.demo in imageLabelKeys",
+          "icon": "${podman-icon}"
+        }
+      ]
+    }
   },
   "scripts": {
     "build": "vite build",

--- a/primary-podify-demo/front/Dockerfile
+++ b/primary-podify-demo/front/Dockerfile
@@ -66,3 +66,5 @@ ENV FLASK_APP=app.py FLASK_RUN_HOST=0.0.0.0
 
 # start flask
 ENTRYPOINT ["/entrypoint.sh"]
+
+LABEL io.podman.demo=awesome


### PR DESCRIPTION
Just implements the easter egg suggested in https://github.com/containers/podman-desktop/issues/3307.

<img width="307" alt="Screenshot 2024-01-26 at 6 16 20 PM" src="https://github.com/redhat-developer/podman-desktop-demo/assets/19958075/0052d63f-b1af-4e10-9554-96e65e5be059">

The frontend is marked with a label, which customizes it with a Podman icon on both the

The icon has an odd aspect ratio atm, but the issue is already logged: https://github.com/containers/podman-desktop/issues/5523