### PR TITLE
feat(compose): add grocery kube play migration demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ There are multiple scripts available
 - *run-containers.sh* : This script starts few containers
 - *pods/start-pods.sh* : This script starts few pods
 - *compose/compose-demo.sh* : This script start a docker-compose 
+- *compose/grocery-kube-play-demo* : Demo project for compose -> kompose -> podman kube play workflow
 
 You can run these scripts individually.
 Or you can use the `init.sh`file to set all things up.

--- a/compose/grocery-kube-play-demo/README.md
+++ b/compose/grocery-kube-play-demo/README.md
@@ -1,3 +1,21 @@
+<!--
+Copyright (C) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Grocery kube play demo
 
 Small demo used by Podman Desktop blog tutorials for:

--- a/compose/grocery-kube-play-demo/README.md
+++ b/compose/grocery-kube-play-demo/README.md
@@ -1,0 +1,45 @@
+# Grocery kube play demo
+
+Small demo used by Podman Desktop blog tutorials for:
+
+1. Running a Compose stack with Podman.
+2. Converting `docker-compose.yml` to Kubernetes YAML with `kompose`.
+3. Running the generated YAML locally with `podman kube play`.
+
+## Stack
+
+- Web: static HTML
+- API: TypeScript + Node.js HTTP + PostgreSQL
+- Database: `registry.access.redhat.com/hi/postgresql:18.4`
+
+## Run with Compose
+
+```bash
+podman compose up -d --build
+```
+
+Open:
+
+- http://localhost:8080
+- http://localhost:3000/health
+- http://localhost:3000/api/items
+
+## Convert to Kubernetes YAML
+
+```bash
+kompose convert --stdout -f docker-compose.yml > app-kube.yaml
+```
+
+## Run generated YAML
+
+```bash
+podman compose down
+podman kube play --replace --publish-all app-kube.yaml
+```
+
+## Cleanup
+
+```bash
+podman compose down -v
+podman kube down app-kube.yaml
+```

--- a/compose/grocery-kube-play-demo/api/Dockerfile
+++ b/compose/grocery-kube-play-demo/api/Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/hi/nodejs:26.5.0-builder AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM registry.access.redhat.com/hi/nodejs:26.5.0
+WORKDIR /app
+COPY --from=build /app/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+ENV PORT=3000
+EXPOSE 3000
+CMD ["node", "dist/index.js"]

--- a/compose/grocery-kube-play-demo/api/Dockerfile
+++ b/compose/grocery-kube-play-demo/api/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM registry.access.redhat.com/hi/nodejs:26.5.0-builder AS build
 WORKDIR /app
 COPY package.json tsconfig.json ./

--- a/compose/grocery-kube-play-demo/api/package.json
+++ b/compose/grocery-kube-play-demo/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "grocery-api",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --enable-source-maps dist/index.js",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "pg": "8.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.1",
+    "@types/pg": "8.20.0",
+    "typescript": "7.0.2"
+  }
+}

--- a/compose/grocery-kube-play-demo/api/src/index.ts
+++ b/compose/grocery-kube-play-demo/api/src/index.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import { createServer } from 'node:http';
 import { URL } from 'node:url';
 import { Pool } from 'pg';

--- a/compose/grocery-kube-play-demo/api/src/index.ts
+++ b/compose/grocery-kube-play-demo/api/src/index.ts
@@ -1,0 +1,130 @@
+import { createServer } from 'node:http';
+import { URL } from 'node:url';
+import { Pool } from 'pg';
+
+const port = Number(process.env.PORT ?? 3000);
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ??
+    'postgresql://grocery:grocery@db:5432/grocery',
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function readJsonBody(req: import('node:http').IncomingMessage): Promise<unknown> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+async function waitForDatabase(maxAttempts = 30): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await pool.query('SELECT 1');
+      return;
+    } catch {
+      await wait(1000);
+    }
+  }
+  throw new Error('Database did not become ready in time');
+}
+
+async function init(): Promise<void> {
+  await waitForDatabase();
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS grocery_items (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL,
+      quantity INTEGER NOT NULL
+    )
+  `);
+
+  const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM grocery_items');
+  if (rows[0].count === 0) {
+    await pool.query(`
+      INSERT INTO grocery_items(name, quantity)
+      VALUES ('Milk', 1), ('Bread', 2), ('Tomatoes', 4)
+    `);
+  }
+}
+
+init()
+  .then(() => {
+    const server = createServer(async (req, res) => {
+      const reqUrl = new URL(req.url ?? '/', 'http://localhost');
+      const allowedOrigins = new Set(['http://localhost:8080', 'http://127.0.0.1:8080']);
+      const origin = req.headers.origin;
+      const isAllowedOrigin = typeof origin === 'string' && allowedOrigins.has(origin);
+
+      if (isAllowedOrigin) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      }
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(isAllowedOrigin ? 204 : 403);
+        res.end();
+        return;
+      }
+
+      if (req.method === 'GET' && reqUrl.pathname === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (req.method === 'GET' && reqUrl.pathname === '/api/items') {
+        try {
+          const { rows } = await pool.query('SELECT id, name, quantity FROM grocery_items ORDER BY id');
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(rows));
+        } catch {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Failed to load items' }));
+        }
+        return;
+      }
+
+      if (req.method === 'POST' && reqUrl.pathname === '/api/items') {
+        try {
+          const body = (await readJsonBody(req)) as { name?: unknown; quantity?: unknown };
+          const name = String(body.name ?? '').trim();
+          const quantity = Number(body.quantity ?? 1);
+
+          if (!name || !Number.isInteger(quantity) || quantity < 1) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'name and positive integer quantity are required' }));
+            return;
+          }
+
+          const { rows } = await pool.query(
+            'INSERT INTO grocery_items(name, quantity) VALUES ($1, $2) RETURNING id, name, quantity',
+            [name, quantity],
+          );
+          res.writeHead(201, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(rows[0]));
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid request body' }));
+        }
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    });
+
+    server.listen(port, () => {
+      console.log(`API started on ${port}`);
+    });
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/compose/grocery-kube-play-demo/api/tsconfig.json
+++ b/compose/grocery-kube-play-demo/api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/compose/grocery-kube-play-demo/docker-compose.yml
+++ b/compose/grocery-kube-play-demo/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: registry.access.redhat.com/hi/postgresql:18.4
+    environment:
+      POSTGRES_USER: grocery
+      POSTGRES_PASSWORD: grocery
+      POSTGRES_DB: grocery
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U grocery -d grocery"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+    ports:
+      - '127.0.0.1:5432:5432'
+    volumes:
+      - grocery-db:/var/lib/postgresql/data
+
+  api:
+    image: api:1.0.0
+    build: ./api
+    environment:
+      DATABASE_URL: postgresql://grocery:grocery@db:5432/grocery
+      PORT: 3000
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - '127.0.0.1:3000:3000'
+
+  web:
+    image: web:1.0.0
+    build: ./web
+    depends_on:
+      - api
+    ports:
+      - '127.0.0.1:8080:8080'
+
+volumes:
+  grocery-db: {}

--- a/compose/grocery-kube-play-demo/docker-compose.yml
+++ b/compose/grocery-kube-play-demo/docker-compose.yml
@@ -1,3 +1,19 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   db:
     image: registry.access.redhat.com/hi/postgresql:18.4

--- a/compose/grocery-kube-play-demo/web/Dockerfile
+++ b/compose/grocery-kube-play-demo/web/Dockerfile
@@ -1,3 +1,19 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM registry.access.redhat.com/hi/nginx:1.30.3
 COPY index.html /usr/share/nginx/html/index.html
 EXPOSE 8080

--- a/compose/grocery-kube-play-demo/web/Dockerfile
+++ b/compose/grocery-kube-play-demo/web/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/hi/nginx:1.30.3
+COPY index.html /usr/share/nginx/html/index.html
+EXPOSE 8080

--- a/compose/grocery-kube-play-demo/web/index.html
+++ b/compose/grocery-kube-play-demo/web/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Grocery list</title>
+  </head>
+  <body>
+    <h1>Grocery list</h1>
+    <form id="add-form">
+      <input id="name" placeholder="Item name" required />
+      <input id="quantity" type="number" min="1" value="1" required />
+      <button type="submit">Add item</button>
+    </form>
+    <ul id="items"></ul>
+    <script>
+      const API_BASE_URL = 'http://localhost:3000';
+
+      async function loadItems() {
+        const response = await fetch(`${API_BASE_URL}/api/items`);
+        const items = await response.json();
+        const list = document.getElementById('items');
+        list.innerHTML = '';
+        for (const item of items) {
+          const li = document.createElement('li');
+          li.textContent = `${item.name} x${item.quantity}`;
+          list.appendChild(li);
+        }
+      }
+
+      document.getElementById('add-form').addEventListener('submit', async event => {
+        event.preventDefault();
+        const name = document.getElementById('name').value.trim();
+        const quantity = Number(document.getElementById('quantity').value);
+        if (!name || quantity < 1) return;
+
+        await fetch(`${API_BASE_URL}/api/items`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, quantity }),
+        });
+
+        document.getElementById('name').value = '';
+        document.getElementById('quantity').value = '1';
+        await loadItems();
+      });
+
+      loadItems();
+    </script>
+  </body>
+</html>

--- a/compose/grocery-kube-play-demo/web/index.html
+++ b/compose/grocery-kube-play-demo/web/index.html
@@ -1,3 +1,21 @@
+<!--
+Copyright (C) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html>
   <head>


### PR DESCRIPTION
## Summary
- add a new `compose/grocery-kube-play-demo` project with a minimal web + TypeScript API + PostgreSQL stack
- document a tested migration flow from Compose to Kubernetes YAML using `kompose` and local validation with `podman kube play`
- pin container image and npm package versions for reproducible workshop/tutorial runs

## Why
This demo content has moved out of the Podman Desktop website repository so docs can reference a reusable standalone demo repository.

Related links:
- Podman Desktop issue: https://github.com/podman-desktop/podman-desktop/issues/18144
- Podman Desktop blog PR: https://github.com/podman-desktop/podman-desktop/pull/18361

## Test plan
- [x] `podman compose up -d --build` succeeds in `compose/grocery-kube-play-demo`
- [x] `kompose convert --stdout -f docker-compose.yml > app-kube.yaml` generates manifests
- [x] `podman kube play --replace --publish-all app-kube.yaml` brings up pods locally
- [x] app endpoints respond at `localhost:8080` and `localhost:3000`

Made with [Cursor](https://cursor.com)