### PR TITLE
chore(guestbook): pin images and stabilize compose-to-kube flow

### DIFF
--- a/guestbook-compose/compose.yaml
+++ b/guestbook-compose/compose.yaml
@@ -19,18 +19,17 @@ services:
   redis-leader:
     container_name: redis-leader
     image: docker.io/library/redis@sha256:234c902a2db49461a129e2d4aeff85b28cf20187ed274a67f6e50995fa713c7b
-    ports:
+    expose:
       - "6379"
 
   redis-replica:
     container_name: redis-replica
     image: docker.io/library/redis@sha256:234c902a2db49461a129e2d4aeff85b28cf20187ed274a67f6e50995fa713c7b
-    ports:
-      - "6379"
     command: redis-server --replicaof redis-leader 6379
 
   web:
     container_name: web
+    image: web:1.0.0
     build: ./web
     ports:
       - "8080:8080"

--- a/guestbook-compose/compose.yaml
+++ b/guestbook-compose/compose.yaml
@@ -1,14 +1,30 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
 
   redis-leader:
     container_name: redis-leader
-    image: redis:latest
+    image: docker.io/library/redis@sha256:234c902a2db49461a129e2d4aeff85b28cf20187ed274a67f6e50995fa713c7b
     ports:
       - "6379"
 
   redis-replica:
     container_name: redis-replica
-    image: redis:latest
+    image: docker.io/library/redis@sha256:234c902a2db49461a129e2d4aeff85b28cf20187ed274a67f6e50995fa713c7b
     ports:
       - "6379"
     command: redis-server --replicaof redis-leader 6379

--- a/guestbook-compose/web/Dockerfile
+++ b/guestbook-compose/web/Dockerfile
@@ -1,4 +1,20 @@
-FROM golang:1.21.2
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM docker.io/library/golang@sha256:013ebb36af72d90db0175b077ffa6469ecccfe10ba2a2389cbbc4c1010a83b96
 WORKDIR /app
 
 # Copy the entire project which includes the public directory, vendoring, etc.


### PR DESCRIPTION
## Summary
- add Apache 2.0 copyright + SPDX headers to `guestbook-compose/compose.yaml` and `guestbook-compose/web/Dockerfile`
- pin rolling images to digests (`redis` and `golang`) and set `web` service image to `web:1.0.0` for local reuse
- adjust Redis networking (`expose` instead of host port publishing) to avoid host port collisions during `podman kube play --publish-all`
- this is the demo-repo update used by the companion website tutorial refresh

Related context:
- Podman Desktop issue: https://github.com/podman-desktop/podman-desktop/issues/18144
- Companion docs branch: `simonrey1/podman-desktop` -> `blog/from-compose-to-kubernetes-kube-play-v2`

## Test plan
- [x] `podman compose -f guestbook-compose/compose.yaml up -d --build`
- [x] `kompose convert --stdout -f guestbook-compose/compose.yaml > guestbook-kube.yaml`
- [x] `podman compose -f guestbook-compose/compose.yaml down`
- [x] `podman kube play --replace --publish-all guestbook-kube.yaml`
- [x] verify `http://localhost:8080` returns HTTP 200
- [x] cleanup with `podman kube down guestbook-kube.yaml`

Made with [Cursor](https://cursor.com)